### PR TITLE
Dangerハッカソン ＃1のデモ

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,6 @@
 # PRしたファイルの直近のコミット履歴を表で可視化する
 
+require "logger"
 require "git"
 g = Git.open("./", :log => Logger.new(STDOUT))
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -38,5 +38,5 @@ files.each do |f|
 end
 
 github.pr_json["reviewers"] = reviewer
-message "#{d[:user]}さんをレビューアにします"
+message "#{reviewer}さんをレビューアにします"
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -11,7 +11,8 @@ files = (git.added_files + git.modified_files) #=> FileList
 N = 5
 
 markdown "## あなたが修正したファイルに関する直近のコミット\n\n"
-markdown "競合はないかよく確認してください…\n"
+markdown "これらの修正は把握していますか？…\n"
+markdown "競合はないかよく確認してください :mask: \n"
 data = []
 reviewer = nil
 files.each do |f|

--- a/Dangerfile
+++ b/Dangerfile
@@ -4,6 +4,7 @@ files = (git.added_files + git.modified_files) #=> FileList
 
 markdown "## あなたが修正したファイルに関する直近のコミット\n\n"
 data = []
+reviewer = nil
 files.each do |f|
 	# gitからそのファイルの履歴を取得する
 	#logs = git.git.gblob(f).log(5)

--- a/Dangerfile
+++ b/Dangerfile
@@ -4,6 +4,7 @@ require "logger"
 require "git"
 g = Git.open("./", :log => Logger.new(STDOUT))
 
+# PRで修正したファイル
 files = (git.added_files + git.modified_files) #=> FileList
 
 # 何個履歴出すか
@@ -15,7 +16,7 @@ reviewer = nil
 files.each do |f|
 
 	# gitからそのファイルの履歴を取得する
-	# XXX PRのコミットでない
+	# XXX PRのブランチ以外のみを参照したい
 	#logs = git.commits
 	logs = g.gblob(f).log(N)
 
@@ -47,5 +48,5 @@ files.each do |f|
 end
 
 github.pr_json["reviewers"] = reviewer
-message "#{reviewer}さんをレビューアにします"
+message "#{reviewer}さんをレビューアにします(自分自身だったらごめんね :kissing_closed_eyes: )"
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -11,6 +11,7 @@ files = (git.added_files + git.modified_files) #=> FileList
 N = 5
 
 markdown "## あなたが修正したファイルに関する直近のコミット\n\n"
+markdown "この辺りの変更と競合はしないか確認してね\n\n"
 data = []
 reviewer = nil
 files.each do |f|

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,14 +1,19 @@
 # PRしたファイルの直近のコミット履歴を表で可視化する
 
+require "git"
+g = Git.open("./", :log => Logger.new(STDOUT))
+
 files = (git.added_files + git.modified_files) #=> FileList
 
 markdown "## あなたが修正したファイルに関する直近のコミット\n\n"
 data = []
 reviewer = nil
 files.each do |f|
+
 	# gitからそのファイルの履歴を取得する
-	#logs = git.git.gblob(f).log(5)
-	logs = git.commits
+	# XXX PRのコミットでない
+	#logs = git.commits
+	logs = g.gblob(f).log(10)
 
 	message = "### #{f}\n\n"
 	message << "date | commit | msg | user |\n"
@@ -25,7 +30,7 @@ files.each do |f|
 		tmp.push(d)
 	    message << "| #{d[:date]} | #{d[:id]} | #{d[:msg]} | #{d[:user]} |\n"	
 
-		# TODO ??
+		# TODO 自分以外
 		reviewer = d[:user]
 	end
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -36,6 +36,6 @@ files.each do |f|
 	
 end
 
-github.pr_json["reviewers"] = d[:user]
+github.pr_json["reviewers"] = reviewer
 message "#{d[:user]}さんをレビューアにします"
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -6,6 +6,9 @@ g = Git.open("./", :log => Logger.new(STDOUT))
 
 files = (git.added_files + git.modified_files) #=> FileList
 
+# 何個履歴出すか
+N = 5
+
 markdown "## あなたが修正したファイルに関する直近のコミット\n\n"
 data = []
 reviewer = nil
@@ -14,7 +17,7 @@ files.each do |f|
 	# gitからそのファイルの履歴を取得する
 	# XXX PRのコミットでない
 	#logs = git.commits
-	logs = g.gblob(f).log(10)
+	logs = g.gblob(f).log(N)
 
 	message = "### #{f}\n\n"
 	message << "date | commit | msg | user |\n"

--- a/Dangerfile
+++ b/Dangerfile
@@ -25,8 +25,7 @@ files.each do |f|
 	    message << "| #{d[:date]} | #{d[:id]} | #{d[:msg]} | #{d[:user]} |\n"	
 
 		# TODO ??
-		github.pr_json["reviewers"] = d[:user]
-		message "#{d[:user]}さんをレビューアにします"
+		reviewer = d[:user]
 	end
 
 	data.push(tmp)
@@ -36,3 +35,7 @@ files.each do |f|
 	# TODO 直近のコミッタをレビューアに設定する
 	
 end
+
+github.pr_json["reviewers"] = d[:user]
+message "#{d[:user]}さんをレビューアにします"
+

--- a/Dangerfile
+++ b/Dangerfile
@@ -11,7 +11,7 @@ files = (git.added_files + git.modified_files) #=> FileList
 N = 5
 
 markdown "## あなたが修正したファイルに関する直近のコミット\n\n"
-markdown "この辺りの変更と競合はしないか確認してね\n\n"
+markdown "競合はないかよく確認してください…\n"
 data = []
 reviewer = nil
 files.each do |f|
@@ -37,6 +37,7 @@ files.each do |f|
 	    message << "| #{d[:date]} | #{d[:id]} | #{d[:msg]} | #{d[:user]} |\n"	
 
 		# TODO 自分以外
+		# TODO 直近のコミッタをレビューアに設定したい
 		reviewer = d[:user]
 	end
 
@@ -44,7 +45,6 @@ files.each do |f|
 	message << "\n\n"
 	markdown message
 
-	# TODO 直近のコミッタをレビューアに設定する
 	
 end
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,7 +2,7 @@
 
 files = (git.added_files + git.modified_files) #=> FileList
 
-markdown "## 直近のコミット\n\n"
+markdown "## あなたが修正したファイルに関する直近のコミット\n\n"
 data = []
 files.each do |f|
 	# gitからそのファイルの履歴を取得する
@@ -23,6 +23,10 @@ files.each do |f|
 		}
 		tmp.push(d)
 	    message << "| #{d[:date]} | #{d[:id]} | #{d[:msg]} | #{d[:user]} |\n"	
+
+		# TODO ??
+		github.pr_json["reviewers"] = d[:user]
+		message "#{d[:user]}さんをレビューアにします"
 	end
 
 	data.push(tmp)

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ hello world of Danger
 ## Contribution
 
 Welcome
+
+aaaaa

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# test test


### PR DESCRIPTION
# danger_reviewer_chooser

## 機能

* 自分がPRしたファイルの直近の更新履歴を表示
* 過去に同じファイルを修正した人をレビューアに設定(WIP)

## なぜつくったの？

* 大規模プロジェクトでは、自分のPRしたファイルを 直前にだれか直してるかも
* 常にWatchするのは難しい
* 自動マージ可能でも、論理的な競合があるかも？

## TODO

- [ ] そもそもレビューアにアサインできてない
- [ ] 自分以外をレビューアに設定。有識者っぽい人が良い
- [ ] 自分のPR以外のブランチのログに限定して表示したい